### PR TITLE
feat(settings): add toggle to show/hide commands in command palette

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,7 @@ export interface Settings {
 	debuggingMode: boolean;
 	notificationsEnabled: boolean;
 	personalAccessToken?: string;
+	showCommandsInRibbon: boolean;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -41,6 +42,7 @@ export const DEFAULT_SETTINGS: Settings = {
 	debuggingMode: false,
 	notificationsEnabled: true,
 	personalAccessToken: "",
+	showCommandsInRibbon: true,
 };
 
 /**

--- a/src/ui/PluginCommands.ts
+++ b/src/ui/PluginCommands.ts
@@ -320,16 +320,34 @@ export default class PluginCommands {
 
 	constructor(plugin: BratPlugin) {
 		this.plugin = plugin;
+		this.registerCommands();
+	}
 
-		for (const item of this.bratCommands) {
-			this.plugin.addCommand({
-				id: item.id,
-				name: item.name,
-				icon: item.icon,
-				callback: () => {
-					item.callback();
-				},
-			});
+	registerCommands(): void {
+		if (this.plugin.settings.showCommandsInRibbon) {
+			for (const item of this.bratCommands) {
+				this.plugin.addCommand({
+					id: item.id,
+					name: item.name,
+					icon: item.icon,
+					callback: () => {
+						item.callback();
+					},
+				});
+			}
 		}
+	}
+
+	unregisterCommands(): void {
+		for (const item of this.bratCommands) {
+			if (this.plugin.app.commands.removeCommand) {
+				this.plugin.app.commands.removeCommand(`${this.plugin.manifest.id}:${item.id}`);
+			}
+		}
+	}
+
+	updateCommandRegistration(): void {
+		this.unregisterCommands();
+		this.registerCommands();
 	}
 }

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -59,6 +59,17 @@ export class BratSettingsTab extends PluginSettingTab {
 				});
 			});
 
+		new Setting(containerEl)
+			.setName("Show commands in command palette")
+			.setDesc("If enabled, BRAT commands will be visible in Obsidian's command palette. Disable this to hide BRAT commands from the command palette while keeping ribbon functionality.")
+			.addToggle((cb: ToggleComponent) => {
+				cb.setValue(this.plugin.settings.showCommandsInRibbon).onChange(async (value: boolean) => {
+				this.plugin.settings.showCommandsInRibbon = value;
+				await this.plugin.saveSettings();
+				this.plugin.commands.updateCommandRegistration();
+			});
+			});
+
 		promotionalLinks(containerEl, true);
 		containerEl.createEl("hr");
 		new Setting(containerEl).setName("Beta plugin list").setHeading();


### PR DESCRIPTION
Add new setting to control visibility of BRAT commands in Obsidian's command palette. This allows users to hide commands while keeping ribbon functionality.

Implement command registration/unregistration logic to dynamically update command palette based on setting changes.